### PR TITLE
Prepare for release v2020.6.23

### DIFF
--- a/charts/stash-community/Chart.yaml
+++ b/charts/stash-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-community
 description: Stash Community Plan
 type: application
-version: v0.9.0-rc.6
-appVersion: v0.9.0-rc.6
+version: v2020.6.23
+appVersion: v2020.6.23
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-community/templates/bundle.yaml
+++ b/charts/stash-community/templates/bundle.yaml
@@ -24,25 +24,25 @@ spec:
       required: true
       url: https://charts.appscode.com/stable
       versions:
-      - version: v0.9.0-rc.6
+      - version: v2020.6.23
   - bundle:
       name: stash-elasticsearch-community
       url: https://bundles.byte.builders/stable
-      version: v0.1.0
+      version: v2020.6.23
   - bundle:
       name: stash-mongodb-community
       url: https://bundles.byte.builders/stable
-      version: v0.1.0
+      version: v2020.6.23
   - bundle:
       name: stash-mysql-community
       url: https://bundles.byte.builders/stable
-      version: v0.1.0
+      version: v2020.6.23
   - bundle:
       name: stash-postgres-community
       url: https://bundles.byte.builders/stable
-      version: v0.1.0
+      version: v2020.6.23
   - bundle:
       name: stash-percona-xtradb-community
       url: https://bundles.byte.builders/stable
-      version: v0.1.0
+      version: v2020.6.23
 status: {}

--- a/charts/stash-elasticsearch-community/Chart.yaml
+++ b/charts/stash-elasticsearch-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-elasticsearch-community
 description: Stash Elasticsearch Addon Community Plan
 type: application
-version: v0.1.0
-appVersion: v0.1.0
+version: v2020.6.23
+appVersion: v2020.6.23
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-elasticsearch-community/templates/bundle.yaml
+++ b/charts/stash-elasticsearch-community/templates/bundle.yaml
@@ -28,35 +28,33 @@ spec:
       - selected: true
         version: "5.6"
       - selected: true
-        version: "5.6.4"
+        version: 5.6.4
       - selected: true
         version: "6.2"
       - selected: true
-        version: "6.2.4"
+        version: 6.2.4
       - selected: true
         version: "6.3"
       - selected: true
-        version: "6.3.0"
+        version: 6.3.0
       - selected: true
         version: "6.4"
       - selected: true
-        version: "6.4.0"
+        version: 6.4.0
       - selected: true
         version: "6.5"
       - selected: true
-        version: "6.5.3"
+        version: 6.5.3
       - selected: true
         version: "6.8"
       - selected: true
-        version: "6.8.0"
+        version: 6.8.0
       - selected: true
         version: "7.2"
       - selected: true
-        version: "7.2.0"
+        version: 7.2.0
       - selected: true
         version: "7.3"
       - selected: true
-        version: "7.3.2"
+        version: 7.3.2
 status: {}
-
-

--- a/charts/stash-enterprise/Chart.yaml
+++ b/charts/stash-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-enterprise
 description: Stash Enterprise Plan
 type: application
-version: v0.9.0-rc.6
-appVersion: v0.9.0-rc.6
+version: v2020.6.23
+appVersion: v2020.6.23
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-enterprise/templates/bundle.yaml
+++ b/charts/stash-enterprise/templates/bundle.yaml
@@ -28,21 +28,21 @@ spec:
   - bundle:
       name: stash-elasticsearch-community
       url: https://bundles.byte.builders/stable
-      version: v0.1.0
+      version: v2020.6.23
   - bundle:
       name: stash-mongodb-community
       url: https://bundles.byte.builders/stable
-      version: v0.1.0
+      version: v2020.6.23
   - bundle:
       name: stash-mysql-community
       url: https://bundles.byte.builders/stable
-      version: v0.1.0
+      version: v2020.6.23
   - bundle:
       name: stash-postgres-community
       url: https://bundles.byte.builders/stable
-      version: v0.1.0
+      version: v2020.6.23
   - bundle:
       name: stash-percona-xtradb-community
       url: https://bundles.byte.builders/stable
-      version: v0.1.0
+      version: v2020.6.23
 status: {}

--- a/charts/stash-mongodb-community/Chart.yaml
+++ b/charts/stash-mongodb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-mongodb-community
 description: Stash MongoDB Addon Community Plan
 type: application
-version: v0.1.0
-appVersion: v0.1.0
+version: v2020.6.23
+appVersion: v2020.6.23
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-mongodb-community/templates/bundle.yaml
+++ b/charts/stash-mongodb-community/templates/bundle.yaml
@@ -28,33 +28,33 @@ spec:
       - selected: true
         version: "3.4"
       - selected: true
-        version: "3.4.17"
+        version: 3.4.17
       - selected: true
-        version: "3.4.22"
+        version: 3.4.22
       - selected: true
         version: "3.6"
       - selected: true
-        version: "3.6.8"
+        version: 3.6.8
       - selected: true
-        version: "3.6.13"
+        version: 3.6.13
       - selected: true
         version: "4.0"
       - selected: true
-        version: "4.0.3"
+        version: 4.0.3
       - selected: true
-        version: "4.0.5"
+        version: 4.0.5
       - selected: true
-        version: "4.0.11"
+        version: 4.0.11
       - selected: true
         version: "4.1"
       - selected: true
-        version: "4.1.4"
+        version: 4.1.4
       - selected: true
-        version: "4.1.7"
+        version: 4.1.7
       - selected: true
-        version: "4.1.13"
+        version: 4.1.13
       - selected: true
         version: "4.2"
       - selected: true
-        version: "4.2.3"
+        version: 4.2.3
 status: {}

--- a/charts/stash-mysql-community/Chart.yaml
+++ b/charts/stash-mysql-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-mysql-community
 description: Stash MySQL Addon Community
 type: application
-version: v0.1.0
-appVersion: v0.1.0
+version: v2020.6.23
+appVersion: v2020.6.23
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-mysql-community/templates/bundle.yaml
+++ b/charts/stash-mysql-community/templates/bundle.yaml
@@ -26,9 +26,9 @@ spec:
       url: https://charts.appscode.com/stable/
       versions:
       - selected: true
-        version: "5.7.25"
+        version: 5.7.25
       - selected: true
-        version: "8.0.3"
+        version: 8.0.3
       - selected: true
-        version: "8.0.14"
+        version: 8.0.14
 status: {}

--- a/charts/stash-percona-xtradb-community/Chart.yaml
+++ b/charts/stash-percona-xtradb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-percona-xtradb-community
 description: Stash Percona XtraDB Addon Community Plan
 type: application
-version: v0.1.0
-appVersion: v0.1.0
+version: v2020.6.23
+appVersion: v2020.6.23
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-postgres-community/Chart.yaml
+++ b/charts/stash-postgres-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-postgres-community
 description: Stash PostgreSQL Addon Community Plan
 type: application
-version: v0.1.0
-appVersion: v0.1.0
+version: v2020.6.23
+appVersion: v2020.6.23
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-postgres-community/templates/bundle.yaml
+++ b/charts/stash-postgres-community/templates/bundle.yaml
@@ -26,13 +26,13 @@ spec:
       url: https://charts.appscode.com/stable/
       versions:
       - selected: true
-        version: "9.6"
+        version: 11.2-v1
       - selected: true
-        version: "10.2"
+        version: 11.1-v1
       - selected: true
-        version: "10.6"
+        version: 10.6-v1
       - selected: true
-        version: "11.1"
+        version: 10.2-v1
       - selected: true
-        version: "11.2"
+        version: 9.6-v1
 status: {}


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.6.23
Release-tracker: https://github.com/appscodelabs/release-automaton-demo/pull/1
Signed-off-by: Tamal Saha <tamal@appscode.com>