### PR TITLE
Prepare for release v2020.09.16

### DIFF
--- a/charts/stash-community/Chart.yaml
+++ b/charts/stash-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-community
 description: Stash Community Plan
 type: application
-version: v2020.08.27
-appVersion: v2020.08.27
+version: v2020.09.16
+appVersion: v2020.09.16
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-community/templates/bundle.yaml
+++ b/charts/stash-community/templates/bundle.yaml
@@ -24,25 +24,25 @@ spec:
       required: true
       url: https://charts.appscode.com/stable
       versions:
-      - version: v0.10.0
+      - version: v0.11.0
   - bundle:
       name: stash-elasticsearch-community
       url: https://bundles.byte.builders/stable
-      version: v2020.08.27
+      version: v2020.09.16
   - bundle:
       name: stash-mongodb-community
       url: https://bundles.byte.builders/stable
-      version: v2020.08.27
+      version: v2020.09.16
   - bundle:
       name: stash-mysql-community
       url: https://bundles.byte.builders/stable
-      version: v2020.08.27
+      version: v2020.09.16
   - bundle:
       name: stash-postgres-community
       url: https://bundles.byte.builders/stable
-      version: v2020.08.27
+      version: v2020.09.16
   - bundle:
       name: stash-percona-xtradb-community
       url: https://bundles.byte.builders/stable
-      version: v2020.08.27
+      version: v2020.09.16
 status: {}

--- a/charts/stash-elasticsearch-community/Chart.yaml
+++ b/charts/stash-elasticsearch-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-elasticsearch-community
 description: Stash Elasticsearch Addon Community Plan
 type: application
-version: v2020.08.27
-appVersion: v2020.08.27
+version: v2020.09.16
+appVersion: v2020.09.16
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-elasticsearch-community/templates/bundle.yaml
+++ b/charts/stash-elasticsearch-community/templates/bundle.yaml
@@ -26,19 +26,19 @@ spec:
       url: https://charts.appscode.com/stable/
       versions:
       - selected: true
-        version: 7.3.2-v1
+        version: 7.3.2-v2
       - selected: true
-        version: 7.2.0-v1
+        version: 7.2.0-v2
       - selected: true
-        version: 6.8.0-v1
+        version: 6.8.0-v2
       - selected: true
-        version: 6.5.3-v1
+        version: 6.5.3-v2
       - selected: true
-        version: 6.4.0-v1
+        version: 6.4.0-v2
       - selected: true
-        version: 6.3.0-v1
+        version: 6.3.0-v2
       - selected: true
-        version: 6.2.4-v1
+        version: 6.2.4-v2
       - selected: true
-        version: 5.6.4-v1
+        version: 5.6.4-v2
 status: {}

--- a/charts/stash-enterprise/Chart.yaml
+++ b/charts/stash-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-enterprise
 description: Stash Enterprise Plan
 type: application
-version: v2020.08.27
-appVersion: v2020.08.27
+version: v2020.09.16
+appVersion: v2020.09.16
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-enterprise/templates/bundle.yaml
+++ b/charts/stash-enterprise/templates/bundle.yaml
@@ -24,25 +24,25 @@ spec:
       required: true
       url: https://charts.appscode.com/stable
       versions:
-      - version: v0.10.0
+      - version: v0.11.0
   - bundle:
       name: stash-elasticsearch-community
       url: https://bundles.byte.builders/stable
-      version: v2020.08.27
+      version: v2020.09.16
   - bundle:
       name: stash-mongodb-community
       url: https://bundles.byte.builders/stable
-      version: v2020.08.27
+      version: v2020.09.16
   - bundle:
       name: stash-mysql-community
       url: https://bundles.byte.builders/stable
-      version: v2020.08.27
+      version: v2020.09.16
   - bundle:
       name: stash-postgres-community
       url: https://bundles.byte.builders/stable
-      version: v2020.08.27
+      version: v2020.09.16
   - bundle:
       name: stash-percona-xtradb-community
       url: https://bundles.byte.builders/stable
-      version: v2020.08.27
+      version: v2020.09.16
 status: {}

--- a/charts/stash-mongodb-community/Chart.yaml
+++ b/charts/stash-mongodb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-mongodb-community
 description: Stash MongoDB Addon Community Plan
 type: application
-version: v2020.08.27
-appVersion: v2020.08.27
+version: v2020.09.16
+appVersion: v2020.09.16
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-mongodb-community/templates/bundle.yaml
+++ b/charts/stash-mongodb-community/templates/bundle.yaml
@@ -26,25 +26,25 @@ spec:
       url: https://charts.appscode.com/stable/
       versions:
       - selected: true
-        version: 4.2.3-v1
+        version: 4.2.3-v2
       - selected: true
-        version: 4.1.7-v1
+        version: 4.1.7-v2
       - selected: true
-        version: 4.1.4-v1
+        version: 4.1.4-v2
       - selected: true
-        version: 4.1.1-v1
+        version: 4.1.1-v2
       - selected: true
-        version: 4.0.11-v1
+        version: 4.0.11-v2
       - selected: true
-        version: 4.0.5-v1
+        version: 4.0.5-v2
       - selected: true
-        version: 4.0.3-v1
+        version: 4.0.3-v2
       - selected: true
-        version: 3.6.8-v1
+        version: 3.6.8-v2
       - selected: true
-        version: 3.6.1-v1
+        version: 3.6.1-v2
       - selected: true
-        version: 3.4.2-v1
+        version: 3.4.2-v2
       - selected: true
-        version: 3.4.1-v1
+        version: 3.4.1-v2
 status: {}

--- a/charts/stash-mysql-community/Chart.yaml
+++ b/charts/stash-mysql-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-mysql-community
 description: Stash MySQL Addon Community
 type: application
-version: v2020.08.27
-appVersion: v2020.08.27
+version: v2020.09.16
+appVersion: v2020.09.16
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-mysql-community/templates/bundle.yaml
+++ b/charts/stash-mysql-community/templates/bundle.yaml
@@ -26,9 +26,9 @@ spec:
       url: https://charts.appscode.com/stable/
       versions:
       - selected: true
-        version: 8.0.14-v1
+        version: 8.0.14-v2
       - selected: true
-        version: 8.0.3-v1
+        version: 8.0.3-v2
       - selected: true
-        version: 5.7.25-v1
+        version: 5.7.25-v2
 status: {}

--- a/charts/stash-percona-xtradb-community/Chart.yaml
+++ b/charts/stash-percona-xtradb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-percona-xtradb-community
 description: Stash Percona XtraDB Addon Community Plan
 type: application
-version: v2020.08.27
-appVersion: v2020.08.27
+version: v2020.09.16
+appVersion: v2020.09.16
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-percona-xtradb-community/templates/bundle.yaml
+++ b/charts/stash-percona-xtradb-community/templates/bundle.yaml
@@ -27,5 +27,5 @@ spec:
       url: https://charts.appscode.com/stable/
       versions:
       - selected: true
-        version: 5.7-v1
+        version: 5.7-v2
 status: {}

--- a/charts/stash-postgres-community/Chart.yaml
+++ b/charts/stash-postgres-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-postgres-community
 description: Stash PostgreSQL Addon Community Plan
 type: application
-version: v2020.08.27
-appVersion: v2020.08.27
+version: v2020.09.16
+appVersion: v2020.09.16
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/icons/android-icon-192x192.png
 sources:

--- a/charts/stash-postgres-community/templates/bundle.yaml
+++ b/charts/stash-postgres-community/templates/bundle.yaml
@@ -26,13 +26,11 @@ spec:
       url: https://charts.appscode.com/stable/
       versions:
       - selected: true
-        version: 11.2-v1
+        version: 12.4.0
       - selected: true
-        version: 11.1-v1
+        version: 11.9.0
       - selected: true
-        version: 10.6-v1
+        version: 10.14.0
       - selected: true
-        version: 10.2-v1
-      - selected: true
-        version: 9.6-v1
+        version: 9.6.19
 status: {}


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.09.16
Release-tracker: https://github.com/stashed/CHANGELOG/pull/8
Signed-off-by: 1gtm <1gtm@appscode.com>