### PR TITLE
Prepare for release v2020.10.21

### DIFF
--- a/charts/stash-community/Chart.yaml
+++ b/charts/stash-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-community
 description: Stash Community Plan
 type: application
-version: v2020.09.29
-appVersion: v2020.09.29
+version: v2020.10.21
+appVersion: v2020.10.21
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/stash-community-icon.png
 sources:

--- a/charts/stash-community/templates/bundle.yaml
+++ b/charts/stash-community/templates/bundle.yaml
@@ -24,25 +24,25 @@ spec:
       required: true
       url: https://charts.appscode.com/stable
       versions:
-      - version: v0.11.2
+      - version: v0.11.3
   - bundle:
       name: stash-elasticsearch-community
       url: https://bundles.byte.builders/stable
-      version: v2020.09.29
+      version: v2020.10.21
   - bundle:
       name: stash-mongodb-community
       url: https://bundles.byte.builders/stable
-      version: v2020.09.29
+      version: v2020.10.21
   - bundle:
       name: stash-mysql-community
       url: https://bundles.byte.builders/stable
-      version: v2020.09.29
+      version: v2020.10.21
   - bundle:
       name: stash-postgres-community
       url: https://bundles.byte.builders/stable
-      version: v2020.09.29
+      version: v2020.10.21
   - bundle:
       name: stash-percona-xtradb-community
       url: https://bundles.byte.builders/stable
-      version: v2020.09.29
+      version: v2020.10.21
 status: {}

--- a/charts/stash-elasticsearch-community/Chart.yaml
+++ b/charts/stash-elasticsearch-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-elasticsearch-community
 description: Stash Elasticsearch Addon Community Plan
 type: application
-version: v2020.09.29
-appVersion: v2020.09.29
+version: v2020.10.21
+appVersion: v2020.10.21
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/addons/elasticsearch-stash-addon.png
 sources:

--- a/charts/stash-elasticsearch-community/templates/bundle.yaml
+++ b/charts/stash-elasticsearch-community/templates/bundle.yaml
@@ -26,19 +26,19 @@ spec:
       url: https://charts.appscode.com/stable/
       versions:
       - selected: true
-        version: 7.3.2-v2
+        version: 7.3.2-v3
       - selected: true
-        version: 7.2.0-v2
+        version: 7.2.0-v3
       - selected: true
-        version: 6.8.0-v2
+        version: 6.8.0-v3
       - selected: true
-        version: 6.5.3-v2
+        version: 6.5.3-v3
       - selected: true
-        version: 6.4.0-v2
+        version: 6.4.0-v3
       - selected: true
-        version: 6.3.0-v2
+        version: 6.3.0-v3
       - selected: true
-        version: 6.2.4-v2
+        version: 6.2.4-v3
       - selected: true
-        version: 5.6.4-v2
+        version: 5.6.4-v3
 status: {}

--- a/charts/stash-enterprise/Chart.yaml
+++ b/charts/stash-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-enterprise
 description: Stash Enterprise Plan
 type: application
-version: v2020.09.29
-appVersion: v2020.09.29
+version: v2020.10.21
+appVersion: v2020.10.21
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/stash-enterprise-icon.png
 sources:

--- a/charts/stash-enterprise/templates/bundle.yaml
+++ b/charts/stash-enterprise/templates/bundle.yaml
@@ -24,25 +24,25 @@ spec:
       required: true
       url: https://charts.appscode.com/stable
       versions:
-      - version: v0.11.2
+      - version: v0.11.3
   - bundle:
       name: stash-elasticsearch-community
       url: https://bundles.byte.builders/stable
-      version: v2020.09.29
+      version: v2020.10.21
   - bundle:
       name: stash-mongodb-community
       url: https://bundles.byte.builders/stable
-      version: v2020.09.29
+      version: v2020.10.21
   - bundle:
       name: stash-mysql-community
       url: https://bundles.byte.builders/stable
-      version: v2020.09.29
+      version: v2020.10.21
   - bundle:
       name: stash-postgres-community
       url: https://bundles.byte.builders/stable
-      version: v2020.09.29
+      version: v2020.10.21
   - bundle:
       name: stash-percona-xtradb-community
       url: https://bundles.byte.builders/stable
-      version: v2020.09.29
+      version: v2020.10.21
 status: {}

--- a/charts/stash-mongodb-community/Chart.yaml
+++ b/charts/stash-mongodb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-mongodb-community
 description: Stash MongoDB Addon Community Plan
 type: application
-version: v2020.09.29
-appVersion: v2020.09.29
+version: v2020.10.21
+appVersion: v2020.10.21
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/addons/mongodb-stash-addon.png
 sources:

--- a/charts/stash-mongodb-community/templates/bundle.yaml
+++ b/charts/stash-mongodb-community/templates/bundle.yaml
@@ -26,25 +26,25 @@ spec:
       url: https://charts.appscode.com/stable/
       versions:
       - selected: true
-        version: 4.2.3-v2
+        version: 4.2.3-v3
       - selected: true
-        version: 4.1.13-v2
+        version: 4.1.13-v3
       - selected: true
-        version: 4.1.7-v2
+        version: 4.1.7-v3
       - selected: true
-        version: 4.1.4-v2
+        version: 4.1.4-v3
       - selected: true
-        version: 4.0.11-v2
+        version: 4.0.11-v3
       - selected: true
-        version: 4.0.5-v2
+        version: 4.0.5-v3
       - selected: true
-        version: 4.0.3-v2
+        version: 4.0.3-v3
       - selected: true
-        version: 3.6.13-v2
+        version: 3.6.13-v3
       - selected: true
-        version: 3.6.8-v2
+        version: 3.6.8-v3
       - selected: true
-        version: 3.4.22-v2
+        version: 3.4.22-v3
       - selected: true
-        version: 3.4.17-v2
+        version: 3.4.17-v3
 status: {}

--- a/charts/stash-mysql-community/Chart.yaml
+++ b/charts/stash-mysql-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-mysql-community
 description: Stash MySQL Addon Community
 type: application
-version: v2020.09.29
-appVersion: v2020.09.29
+version: v2020.10.21
+appVersion: v2020.10.21
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/addons/mysql-stash-addon.png
 sources:

--- a/charts/stash-mysql-community/templates/bundle.yaml
+++ b/charts/stash-mysql-community/templates/bundle.yaml
@@ -26,9 +26,9 @@ spec:
       url: https://charts.appscode.com/stable/
       versions:
       - selected: true
-        version: 8.0.14-v2
+        version: 8.0.14-v3
       - selected: true
-        version: 8.0.3-v2
+        version: 8.0.3-v3
       - selected: true
-        version: 5.7.25-v2
+        version: 5.7.25-v3
 status: {}

--- a/charts/stash-percona-xtradb-community/Chart.yaml
+++ b/charts/stash-percona-xtradb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-percona-xtradb-community
 description: Stash Percona XtraDB Addon Community Plan
 type: application
-version: v2020.09.29
-appVersion: v2020.09.29
+version: v2020.10.21
+appVersion: v2020.10.21
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/addons/perconaxtradb-stash-addon.png
 sources:

--- a/charts/stash-percona-xtradb-community/templates/bundle.yaml
+++ b/charts/stash-percona-xtradb-community/templates/bundle.yaml
@@ -27,5 +27,5 @@ spec:
       url: https://charts.appscode.com/stable/
       versions:
       - selected: true
-        version: 5.7-v2
+        version: 5.7-v3
 status: {}

--- a/charts/stash-postgres-community/Chart.yaml
+++ b/charts/stash-postgres-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-postgres-community
 description: Stash PostgreSQL Addon Community Plan
 type: application
-version: v2020.09.29
-appVersion: v2020.09.29
+version: v2020.10.21
+appVersion: v2020.10.21
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/addons/postgres-stash-addon.png
 sources:

--- a/charts/stash-postgres-community/templates/bundle.yaml
+++ b/charts/stash-postgres-community/templates/bundle.yaml
@@ -26,11 +26,11 @@ spec:
       url: https://charts.appscode.com/stable/
       versions:
       - selected: true
-        version: 12.4.0
+        version: 12.4.0-v1
       - selected: true
-        version: 11.9.0
+        version: 11.9.0-v1
       - selected: true
-        version: 10.14.0
+        version: 10.14.0-v1
       - selected: true
-        version: 9.6.19
+        version: 9.6.19-v1
 status: {}


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.10.21
Release-tracker: https://github.com/stashed/CHANGELOG/pull/16
Signed-off-by: 1gtm <1gtm@appscode.com>