### PR TITLE
Prepare for release v2020.10.29

### DIFF
--- a/charts/stash-community/Chart.yaml
+++ b/charts/stash-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-community
 description: Stash Community Plan
 type: application
-version: v2020.10.21
-appVersion: v2020.10.21
+version: v2020.10.29
+appVersion: v2020.10.29
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/stash-community-icon.png
 sources:

--- a/charts/stash-community/templates/bundle.yaml
+++ b/charts/stash-community/templates/bundle.yaml
@@ -24,25 +24,25 @@ spec:
       required: true
       url: https://charts.appscode.com/stable
       versions:
-      - version: v0.11.3
+      - version: v0.11.4
   - bundle:
       name: stash-elasticsearch-community
       url: https://bundles.byte.builders/stable
-      version: v2020.10.21
+      version: v2020.10.29
   - bundle:
       name: stash-mongodb-community
       url: https://bundles.byte.builders/stable
-      version: v2020.10.21
+      version: v2020.10.29
   - bundle:
       name: stash-mysql-community
       url: https://bundles.byte.builders/stable
-      version: v2020.10.21
+      version: v2020.10.29
   - bundle:
       name: stash-postgres-community
       url: https://bundles.byte.builders/stable
-      version: v2020.10.21
+      version: v2020.10.29
   - bundle:
       name: stash-percona-xtradb-community
       url: https://bundles.byte.builders/stable
-      version: v2020.10.21
+      version: v2020.10.29
 status: {}

--- a/charts/stash-elasticsearch-community/Chart.yaml
+++ b/charts/stash-elasticsearch-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-elasticsearch-community
 description: Stash Elasticsearch Addon Community Plan
 type: application
-version: v2020.10.21
-appVersion: v2020.10.21
+version: v2020.10.29
+appVersion: v2020.10.29
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/addons/elasticsearch-stash-addon.png
 sources:

--- a/charts/stash-enterprise/Chart.yaml
+++ b/charts/stash-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-enterprise
 description: Stash Enterprise Plan
 type: application
-version: v2020.10.21
-appVersion: v2020.10.21
+version: v2020.10.29
+appVersion: v2020.10.29
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/stash-enterprise-icon.png
 sources:

--- a/charts/stash-enterprise/templates/bundle.yaml
+++ b/charts/stash-enterprise/templates/bundle.yaml
@@ -24,25 +24,25 @@ spec:
       required: true
       url: https://charts.appscode.com/stable
       versions:
-      - version: v0.11.3
+      - version: v0.11.4
   - bundle:
       name: stash-elasticsearch-community
       url: https://bundles.byte.builders/stable
-      version: v2020.10.21
+      version: v2020.10.29
   - bundle:
       name: stash-mongodb-community
       url: https://bundles.byte.builders/stable
-      version: v2020.10.21
+      version: v2020.10.29
   - bundle:
       name: stash-mysql-community
       url: https://bundles.byte.builders/stable
-      version: v2020.10.21
+      version: v2020.10.29
   - bundle:
       name: stash-postgres-community
       url: https://bundles.byte.builders/stable
-      version: v2020.10.21
+      version: v2020.10.29
   - bundle:
       name: stash-percona-xtradb-community
       url: https://bundles.byte.builders/stable
-      version: v2020.10.21
+      version: v2020.10.29
 status: {}

--- a/charts/stash-mongodb-community/Chart.yaml
+++ b/charts/stash-mongodb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-mongodb-community
 description: Stash MongoDB Addon Community Plan
 type: application
-version: v2020.10.21
-appVersion: v2020.10.21
+version: v2020.10.29
+appVersion: v2020.10.29
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/addons/mongodb-stash-addon.png
 sources:

--- a/charts/stash-mysql-community/Chart.yaml
+++ b/charts/stash-mysql-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-mysql-community
 description: Stash MySQL Addon Community
 type: application
-version: v2020.10.21
-appVersion: v2020.10.21
+version: v2020.10.29
+appVersion: v2020.10.29
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/addons/mysql-stash-addon.png
 sources:

--- a/charts/stash-percona-xtradb-community/Chart.yaml
+++ b/charts/stash-percona-xtradb-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-percona-xtradb-community
 description: Stash Percona XtraDB Addon Community Plan
 type: application
-version: v2020.10.21
-appVersion: v2020.10.21
+version: v2020.10.29
+appVersion: v2020.10.29
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/addons/perconaxtradb-stash-addon.png
 sources:

--- a/charts/stash-postgres-community/Chart.yaml
+++ b/charts/stash-postgres-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-postgres-community
 description: Stash PostgreSQL Addon Community Plan
 type: application
-version: v2020.10.21
-appVersion: v2020.10.21
+version: v2020.10.29
+appVersion: v2020.10.29
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/addons/postgres-stash-addon.png
 sources:


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.10.29
Release-tracker: https://github.com/stashed/CHANGELOG/pull/21
Signed-off-by: 1gtm <1gtm@appscode.com>