### PR TITLE
Prepare for release v2022.03.29

### DIFF
--- a/charts/stash-community/Chart.yaml
+++ b/charts/stash-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-community
 description: Stash Community Plan
 type: application
-version: v2022.02.22
-appVersion: v2022.02.22
+version: v2022.03.29
+appVersion: v2022.03.29
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/stash-community-icon.png
 sources:

--- a/charts/stash-community/templates/bundle.yaml
+++ b/charts/stash-community/templates/bundle.yaml
@@ -24,5 +24,5 @@ spec:
       required: true
       url: https://charts.appscode.com/stable
       versions:
-      - version: v0.18.0
+      - version: v0.19.0
 status: {}

--- a/charts/stash-enterprise/Chart.yaml
+++ b/charts/stash-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-enterprise
 description: Stash Enterprise Plan
 type: application
-version: v2022.02.22
-appVersion: v2022.02.22
+version: v2022.03.29
+appVersion: v2022.03.29
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/stash-enterprise-icon.png
 sources:

--- a/charts/stash-enterprise/templates/bundle.yaml
+++ b/charts/stash-enterprise/templates/bundle.yaml
@@ -24,7 +24,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable
       versions:
-      - version: v0.18.0
+      - version: v0.19.0
   - chart:
       features:
       - Stash Addon Catalog by AppsCode
@@ -32,5 +32,5 @@ spec:
       required: true
       url: https://charts.appscode.com/stable
       versions:
-      - version: v0.18.0
+      - version: v0.19.0
 status: {}


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.03.29
Release-tracker: https://github.com/stashed/CHANGELOG/pull/46
Signed-off-by: 1gtm <1gtm@appscode.com>