### PR TITLE
Prepare for release v2022.06.21

### DIFF
--- a/charts/stash-community/Chart.yaml
+++ b/charts/stash-community/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-community
 description: Stash Community Plan
 type: application
-version: v2022.05.18
-appVersion: v2022.05.18
+version: v2022.06.21
+appVersion: v2022.06.21
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/stash-community-icon.png
 sources:

--- a/charts/stash-community/templates/bundle.yaml
+++ b/charts/stash-community/templates/bundle.yaml
@@ -24,5 +24,5 @@ spec:
       required: true
       url: https://charts.appscode.com/stable
       versions:
-      - version: v0.20.1
+      - version: v0.21.0
 status: {}

--- a/charts/stash-enterprise/Chart.yaml
+++ b/charts/stash-enterprise/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: stash-enterprise
 description: Stash Enterprise Plan
 type: application
-version: v2022.05.18
-appVersion: v2022.05.18
+version: v2022.06.21
+appVersion: v2022.06.21
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/stash-enterprise-icon.png
 sources:

--- a/charts/stash-enterprise/templates/bundle.yaml
+++ b/charts/stash-enterprise/templates/bundle.yaml
@@ -24,7 +24,7 @@ spec:
       required: true
       url: https://charts.appscode.com/stable
       versions:
-      - version: v0.20.1
+      - version: v0.21.0
   - chart:
       features:
       - Stash Addon Catalog by AppsCode
@@ -32,5 +32,5 @@ spec:
       required: true
       url: https://charts.appscode.com/stable
       versions:
-      - version: v0.20.1
+      - version: v0.21.0
 status: {}


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.06.21
Release-tracker: https://github.com/stashed/CHANGELOG/pull/49
Signed-off-by: 1gtm <1gtm@appscode.com>